### PR TITLE
Replace usage of `Kernel.open` to `URI#read`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Replace usage of `Kernel.open` to `URI#read`
+
 ## 0.14.0 (2021-05-26)
 
 ### New Features

--- a/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
@@ -11,10 +11,10 @@ module OnlyofficeWebdriverWrapper
     end
 
     # Download temp file and return it location
-    # @param file [String] url
+    # @param file_url [String] url
     # @return [String] path to file
     def download(file_url)
-      data = Kernel.open(file_url, &:read)
+      data = URI.parse(file_url).open.read
       file = Tempfile.new('onlyoffice-downloaded-file')
       file.write(data.force_encoding('UTF-8'))
       file.close


### PR DESCRIPTION
Old variant generates warning
```
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```