### PR TITLE
Force `-disable-gpu` for `chromedriver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Force `-disable-gpu` for `chromedriver`
+
 ## 0.16.0 (2021-07-26)
 
 ### New Features

--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -8,6 +8,7 @@ module OnlyofficeWebdriverWrapper
     include ChromeVersionHelper
 
     DEFAULT_CHROME_SWITCHES = %w[--kiosk-printing
+                                 --disable-gpu
                                  --disable-popup-blocking
                                  --disable-infobars
                                  --no-sandbox


### PR DESCRIPTION
Do not know the reason, but seems without this option Chrome 92
are failing to start with
```
X connection error received
```
in chromedriver logs

Don't know why but hope this helps