### PR TITLE
Fix `gem` license name warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * Update `geckodriver` from `v0.31.0` to `v0.34.0`
 
+### Fixes
+
+* Fix `gem` license name warning
+
 ## 1.21.0 (2023-12-07)
 
 ### New Feature

--- a/onlyoffice_webdriver_wrapper.gemspec
+++ b/onlyoffice_webdriver_wrapper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
   s.files = Dir['lib/**/*']
-  s.license = 'AGPL-3.0'
+  s.license = 'AGPL-3.0-or-later'
   s.add_runtime_dependency('headless', '~> 2')
   s.add_runtime_dependency('onlyoffice_file_helper', '< 3')
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')


### PR DESCRIPTION
The warning is:
```
WARNING:  License identifier 'AGPL-3.0' is deprecated. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'AFL-3.0', 'APL-1.0'?

```