### PR TITLE
Fix `gem build` warning related to duplicate metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### Fixes
 
-* Fix `gem` license name warning
+* Fix `gem build` license name warning
+* Fix `gem build` warning related to duplicate metadata
 
 ## 1.21.0 (2023-12-07)
 

--- a/onlyoffice_webdriver_wrapper.gemspec
+++ b/onlyoffice_webdriver_wrapper.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => "#{s.homepage}/issues",
     'changelog_uri' => "#{s.homepage}/blob/master/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}",
-    'homepage_uri' => s.homepage,
     'source_code_uri' => s.homepage,
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
Warning is like:

```
WARNING:  You have specified the uri:
  https://github.com/ONLYOFFICE-QA/onlyoffice_webdriver_wrapper
for all of the following keys:
  homepage_uri
  source_code_uri
Only the first one will be shown on rubygems.org
WARNING:  See https://guides.rubygems.org/specification-reference/ for help

```