### PR TITLE
Introduce `rspec-retry` to gem spec, to handle flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Introduce `rspec-retry` to gem spec, to handle flaky tests
+
 ## 1.27.0 (2024-05-22)
 
 ### New Features

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :test do
   gem 'rspec', '~> 3'
+  gem 'rspec-retry', '~> 0'
   gem 'simplecov-cobertura', '~> 2', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.1)
     rubocop (1.64.1)
       json (~> 2.3)
@@ -141,6 +143,7 @@ DEPENDENCIES
   overcommit (~> 0)
   rake (~> 13)
   rspec (~> 3)
+  rspec-retry (~> 0)
   rubocop (~> 1)
   rubocop-packaging (~> 0)
   rubocop-performance (~> 1)
@@ -150,4 +153,4 @@ DEPENDENCIES
   yard (~> 0, >= 0.9.20)
 
 BUNDLED WITH
-   2.5.10
+   2.5.12

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,13 @@ if ENV['CI']
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 require 'onlyoffice_webdriver_wrapper'
+require 'rspec/retry'
+
+RSpec.configure do |config|
+  config.default_retry_count = 3
+  config.display_try_failure_messages = true
+  config.verbose_retry = true
+end
 
 # Get full path for open in browser of local file
 # @param file_name [String] name of file to load

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'rspec/retry'
 
 RSpec.configure do |config|
   config.default_retry_count = 3
+  config.default_sleep_interval = 15
   config.display_try_failure_messages = true
   config.verbose_retry = true
 end


### PR DESCRIPTION
This will fix some flaky test, that sometimes happens on GitHub Actions Like:

```
 1) OnlyofficeWebdriverWrapper::WebDriver#switch_to_popup Calling webdriver method on popup window until it stopped loading not cause it never load
     Failure/Error: raise(e.class, "Browser is crushed or hangup with #{e}")

     Net::ReadTimeout:
       Net::ReadTimeout with "Browser is crushed or hangup with Net::ReadTimeout"
     # ./lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_navigation_methods.rb:26:in `rescue in current_url'
     # ./lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_navigation_methods.rb:23:in `current_url'
     # ./spec/onlyoffice_webdriver_wrapper/web_driver/switch_to_popup_spec.rb:14:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Net::ReadTimeout:
     #   Net::ReadTimeout with #<TCPSocket:(closed)>
     #   ./lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_js_methods.rb:11:in `execute_javascript'
```

We were never able to reproduce it locally, so probably something related to GitHub Actions only
Tryed by this command:
```
while rspec spec/onlyoffice_webdriver_wrapper/web_driver/switch_to_popup_spec.rb; do :; done
```
Run around a half-hour on my local machine - zero failures