### PR TITLE
Fix running CI on `ubuntu-latest` which is Ubuntu 24 now

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt -y install \
-                      ffmpeg
+                      ffmpeg \
                       imagemagick
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,10 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install google-chrome-stable
       - name: Install dependencies
-        run: sudo apt -y install ffmpeg
+        run: |
+          sudo apt -y install \
+                      ffmpeg
+                      imagemagick
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fix
+
+* Fix running CI on `ubuntu-latest` which is Ubuntu 24 now
+
 ## 1.31.0 (2024-09-30)
 
 ### New Features


### PR DESCRIPTION
Default GitHub Actions updated from Ubuntu 22.04 to Ubuntu 24.04

Ubuntu 24 includes `imagemagick` by default:

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

Ubuntu 24 is not:

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

Notice about rollout: https://github.com/actions/runner-images/issues/10636